### PR TITLE
shuffle.js: remove newlines and carriage returns from gdPath before using it

### DIFF
--- a/shuffle.js
+++ b/shuffle.js
@@ -36,7 +36,8 @@ let iconRegex = /^.+?_(\d+?)_.+/
 let forms = assets.forms
 let sheetList = Object.keys(assets.sheets)
 let glowName = sheetList.filter(x => x.startsWith('GJ_GameSheetGlow'))
-let gdPath = fs.readFileSync('directory.txt', 'utf8')
+// newlines/CRs are usually present in text files, strip them out so they aren't part of the pathname
+let gdPath = fs.readFileSync('directory.txt', 'utf8').replace(/[\n\r]/g, '')
 if (!fs.existsSync(gdPath)) throw "Couldn't find your GD directory! Make sure to enter the correct file path in directory.txt"  
 let glowPlist = fs.readFileSync(`${gdPath}/${glowName[0]}.plist`, 'utf8')
 let sheetNames = sheetList.filter(x => !glowName.includes(x))


### PR DESCRIPTION
A lot of users that edit `directory.txt` may get the couldn't find your GD directory error because there's a newline (or maybe a carriage return) in it which a lot of editors add at the end of the file (the popular Windows Notepad is an exception when creating new files). There's a whole rabbit hole you can go down on about line endings but essentially this PR removes them because otherwise they're read as part of the pathname which will cause the game directory to not be found.