### PR TITLE
shuffle.js: support reading dir from argv[2]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,3 +20,8 @@ HOW TO USE:
 
 If the program closes as soon as you open it, that means it crashed.
 A file called crash_log.txt will be created - send it to Colon and he'll hopefully get around to fixing it.
+
+===
+
+Mac/Linux/non-Windows users, or if the game is installed in a nonstandard location:
+Replace the directory in directory.txt with whereever the game's Resources folder is located on your system, or simply pass it as a command-line argument.

--- a/shuffle.js
+++ b/shuffle.js
@@ -36,7 +36,7 @@ let iconRegex = /^.+?_(\d+?)_.+/
 let forms = assets.forms
 let sheetList = Object.keys(assets.sheets)
 let glowName = sheetList.filter(x => x.startsWith('GJ_GameSheetGlow'))
-let gdPath = fs.readFileSync('directory.txt', 'utf8')
+let gdPath = process.argv[2] ?? fs.readFileSync('directory.txt', 'utf8')
 if (!fs.existsSync(gdPath)) throw "Couldn't find your GD directory! Make sure to enter the correct file path in directory.txt"  
 let glowPlist = fs.readFileSync(`${gdPath}/${glowName[0]}.plist`, 'utf8')
 let sheetNames = sheetList.filter(x => !glowName.includes(x))


### PR DESCRIPTION
Simply allow the directory to be specified as a command-line argument instead of reading from a file, eg.
```
shuffle.js /path/to/GD/Resources
```